### PR TITLE
Add a legend control

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -6,3 +6,21 @@ body {
 #map {
   height: 100%;
 }
+.info {
+	padding: 6px 8px;
+	background: white;
+	background: rgba(255,255,255,0.8);
+	box-shadow: 0 0 15px rgba(0,0,0,0.2);
+	border-radius: 5px;
+}
+.legend {
+  line-height: 18px;
+  color: #555;
+}
+.legend i {
+  width: 18px;
+  height: 18px;
+  float: left;
+  margin-right: 8px;
+  opacity: 0.7;
+}

--- a/js/map.js
+++ b/js/map.js
@@ -10,13 +10,13 @@ function init() {
 	// Add geoJSON layer for private parcels
 	L.geoJson(parcels, {
 		onEachFeature: bindPrivateInfo, // Call this function on each geoJSON feature
-		style: { 'color': '#FF0000' }
+		style: { 'color': parcelColors["private"] }
 	}).addTo(map);
 	
 	// Add geoJSON layer for state parcels
 	L.geoJson(state_parcels, {
 		onEachFeature: bindStateInfo,
-		style: { 'color': '#B31453' }
+		style: { 'color': parcelColors["state"] }
 	}).addTo(map);
 	
 	// Add search box
@@ -24,6 +24,19 @@ function init() {
         provider: new L.GeoSearch.Provider.Google(),
         position: 'topcenter'
     }).addTo(map);
+
+  // Add legend
+  var legend = L.control({position: 'bottomright'});
+  legend.onAdd = function (map) {
+    var div = L.DomUtil.create('div', 'info legend'), labels = [];
+
+		labels.push('<i style="background:' + parcelColors["private"] + '"></i> ' + 'private parcels');
+		labels.push('<i style="background:' + parcelColors["state"] + '"></i> ' + 'state parcels');
+
+		div.innerHTML = labels.join('<br>');
+		return div;
+  };
+  legend.addTo(map);
 }
 
 // Attach an informational popup to each polygon
@@ -35,4 +48,10 @@ function bindPrivateInfo(feature, layer) {
 function bindStateInfo(feature, layer) {
 	layer.bindPopup('Description: ' + feature.properties.ownerdesc + '<br>' +
 					'Lesee Name: ' + feature.properties.vn_leseenm );
+}
+
+// get color depending on parcel type
+parcelColors = {
+  "private": "#FF0000",
+  "state": "#B31453"
 }


### PR DESCRIPTION
This PR adds a small legend control in the bottom right of the map. Ideally, it'd be refactored to programmatically push labels based on the datasets provided, but wanted a working solution first.

This also includes a small change of pulling out the parcel color to a separate object to make interacting with the colors a little easier.
